### PR TITLE
Handle Uint8Array inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,11 @@ const assert = require('assert')
  * RLP Encoding based on: https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-RLP
  * This function takes in a data, convert it to buffer if not, and a length for recursion
  *
- * @param {Buffer,String,Integer,Array} data - will be converted to buffer
+ * @param {Buffer,String,Integer,Array,Uint8Array} data - will be converted to buffer
  * @returns {Buffer} - returns buffer of encoded data
  **/
 exports.encode = function (input) {
-  if (input instanceof Array) {
+  if (input instanceof Array || (input instanceof Uint8Array && !Buffer.isBuffer(input))) {
     var output = []
     for (var i = 0; i < input.length; i++) {
       output.push(exports.encode(input[i]))

--- a/test/index.js
+++ b/test/index.js
@@ -155,6 +155,17 @@ describe('nested lists:', function () {
       ]
     ]
   ]
+  var valueList = [
+    [1, 2, 3],
+    [
+      [4, 5, 6],
+      [7, 8, 9],
+      [
+        [0],
+        Buffer.from('abcd', 'hex')
+      ]
+    ]
+  ]
   var encoded
   it('encode a nested list', function () {
     encoded = RLP.encode(nestedList)
@@ -164,6 +175,31 @@ describe('nested lists:', function () {
   it('should decode a nested list', function () {
     var decoded = RLP.decode(encoded)
     assert.deepEqual(nestedList, decoded)
+  })
+
+  it('should encode a list with values', function () {
+    var valueEncoded = RLP.encode(valueList)
+    assert.deepEqual(valueEncoded, Buffer.from([0xd3, 0xc3, 0x01, 0x02, 0x03, 0xce, 0xc3, 0x04, 0x05, 0x06, 0xc3, 0x07, 0x08, 0x09, 0xc5, 0xc1, 0x80, 0x82, 0xab, 0xcd]))
+  })
+})
+
+describe('typed lists:', function () {
+  var valueList = [
+    new Uint8Array([1, 2, 3]),
+    [
+      new Uint8Array([4, 5, 6]),
+      [7, 8, 9],
+      [
+        new Uint8Array([0]),
+        Buffer.from('abcd', 'hex')
+      ]
+    ]
+  ]
+
+  // equivalent to list of values above
+  it('encode a nested list', function () {
+    var valueEncoded = RLP.encode(valueList)
+    assert.deepEqual(valueEncoded, new Buffer([0xd3, 0xc3, 0x01, 0x02, 0x03, 0xce, 0xc3, 0x04, 0x05, 0x06, 0xc3, 0x07, 0x08, 0x09, 0xc5, 0xc1, 0x80, 0x82, 0xab, 0xcd]))
   })
 })
 


### PR DESCRIPTION
- Cater for Uint8Array input values, handling it in the same way as normal Arrays
- Expand tests to show equivalence between Array (with bytes) & Uint8Array