### PR TITLE
encoding of 0 should be the byte 0 and not the empty buffer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ function toBuffer (v) {
       }
     } else if (typeof v === 'number') {
       if (!v) {
-        v = Buffer.from([])
+        v = Buffer.alloc(1)
       } else {
         v = intToBuffer(v)
       }

--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ function toBuffer (v) {
       }
     } else if (typeof v === 'number') {
       if (!v) {
-        v = Buffer.alloc(1)
+        v = Buffer.from([0])
       } else {
         v = intToBuffer(v)
       }

--- a/test/index.js
+++ b/test/index.js
@@ -75,7 +75,7 @@ describe('RLP encoding (integer):', function () {
   })
 
   it('it should handle zero', function () {
-    assert.equal(RLP.encode(0).toString('hex'), '80')
+    assert.equal(RLP.encode(0).toString('hex'), '00')
   })
 })
 


### PR DESCRIPTION
As stated in the spec,

`For a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.`

Therefore, `rlp.encode(0)` should return `<Buffer 00>`. 

Fixes #28.