### PR TITLE
Add .npmignore File to Make NPM Package Cleaner

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "directories": {
     "test": "test"
   },
+  "files": [
+    "/bin/*",
+    "/index.js",
+    "/index.d.ts"
+  ],
   "scripts": {
     "coverage": "istanbul cover _mocha",
     "coveralls": "npm run coverage && coveralls <coverage/lcov.info",


### PR DESCRIPTION
Hello!

I've noticed that [this project has some test files in npm registry](https://zitros.github.io/npm-explorer/?p=rlp) (as for [v2.1.0](https://zitros.github.io/npm-explorer/?p=rlp@2.1.0)). This pull request adds `.npmignore` file will prevent test files from going to npm.

Thanks!