### PR TITLE
Bump EthereumJS config version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@ethereumjs/config-nyc": "^1.0.0",
-    "@ethereumjs/config-prettier": "^1.0.0",
+    "@ethereumjs/config-prettier": "^1.0.1",
     "@ethereumjs/config-tsc": "^1.0.0",
     "@ethereumjs/config-tslint": "^1.0.0",
     "@types/bn.js": "^4.11.3",


### PR DESCRIPTION
This PR bumps the version of the Prettier config we're using to include https://github.com/ethereumjs/ethereumjs-config/pull/6