### PR TITLE
Fix BN.js import issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@ethereumjs/config-nyc": "^1.0.0",
     "@ethereumjs/config-prettier": "^1.0.1",
-    "@ethereumjs/config-tsc": "^1.0.0",
+    "@ethereumjs/config-tsc": "^1.0.2",
     "@ethereumjs/config-tslint": "^1.0.0",
     "@types/bn.js": "^4.11.3",
     "@types/mocha": "^5.2.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import BN from 'bn.js'
+import BN = require('bn.js')
 
 import { RLPInput, RLPDecoded } from './types'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import BN from 'bn.js'
+import BN = require('bn.js')
 
 export type RLPInput = Buffer | string | number | Uint8Array | BN | RLPObject | RLPArray | null
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -62,6 +62,13 @@ describe('RLP encoding (list):', function() {
   // })
 })
 
+describe('RLP encoding (BN):', function() {
+  it('should encode a BN value', function() {
+    const encodedBN = RLP.encode(new BN(3))
+    assert.equal(encodedBN[0], 3)
+  })
+})
+
 describe('RLP encoding (integer):', function() {
   it('length of int = 1, less than 0x7f, similar to string', function() {
     const encodedNumber = RLP.encode(15)


### PR DESCRIPTION
Fixes an issue with the BN.js import causing the library to error on ``BN.isBN()`` call.

Fixes #53 