### PR TITLE
New release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v2.2.0] - 2018-12-17
+
+First `TypeScript` based release of `EthereumJS` libraries, thanks @krzkaczor,
+@GrandSchtroumpf, @whymarrh, @holgerd77 for the great work on this!
+
+This release doesn't introduce any main new features but will serve as a basis
+for further `TypeScript` transitions coming along with greater type safety
+for `EthereumJS` libraries. If you are developing in `TypeScript` you can
+further already benefit from the `RLP` type declarations published from now on
+along new releases.
+
+See PR [#37](https://github.com/ethereumjs/rlp/pull/37) and subsequent PRs merged
+towards the associated `typescript` branch to get an overview on the changes.
+The release also comes along with the introduction of a new repo
+[ethereumjs-config](https://github.com/ethereumjs/ethereumjs-config) centralizing
+configuration for `EthereumJS` libraries on `TypeScript` itself as well as
+linting, formatting and testing.
+
+This release passes all existing unit tests and other checks. If you nevertheless
+experience problems please report on the `EthereumJS`
+[Gitter](https://gitter.im/ethereum/ethereumjs) channel.
+
+Other changes:
+
+- Added `LICENSE` file for `MPL2.0`, see PR [#31](https://github.com/ethereumjs/rlp/pull/31)
+
+[v2.2.0]: https://github.com/ethereumjs/rlp/compare/2.1.0...v2.2.0
+
 ## [v2.1.0] - 2018-06-28
 
 - Updated supported Node versions, PR [#13](https://github.com/ethereumjs/rlp/pull/13)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rlp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Recursive Length Prefix Encoding Module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "tsc -p ./tsconfig.prod.json",
+    "prepublishOnly": "npm run test && npm run build",
     "coverage": "nyc mocha --reporter spec --require ts-node/register test/index.ts",
     "coveralls": "npm run coverage && nyc report --reporter=text-lcov | coveralls",
     "format": "prettier --list-different **/*.{ts,json,md,gql}",
@@ -19,8 +20,9 @@
     "tsc": "tsc --noEmit",
     "lint": "npm run format && npm run tslint && npm run tsc",
     "lint:fix": "npm run format:fix && npm run tslint:fix && npm run tsc",
-    "test": "npm run lint && mocha --reporter spec --require ts-node/register test/index.ts",
-    "test:fix": "npm run lint:fix && mocha --reporter spec --require ts-node/register test/index.ts",
+    "unitTests": "mocha --reporter spec --require ts-node/register test/index.ts",
+    "test": "npm run lint && npm run unitTests",
+    "test:fix": "npm run lint:fix && npm run unitTests",
     "webtest": "browserify test/max.js | testling -u"
   },
   "repository": {


### PR DESCRIPTION
Ok, here is the PR for the release! :smile:

I did a few modifications on scripts:

**New prepublishOnly command**, rationale:
This should help avoid mistakes on publishing by running the tests and then the build before, we already have this in other libraries.

**Separated unitTests command**, rationale:
This avoids the doubling of the script parametrization for ``test`` and ``test:fix`` command, I would also like to have the ability to easily just run the unit tests throughout development and e.g. temporarily inject ``console.log()`` statements for testing.

Ok, will publish this once I have a first approval by one of you guys. 😄