### PR TITLE
Fix official and integration tests

### DIFF
--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { exec } from 'child_process'
-import * as RLP from '../dist'
+import * as RLP from '../src'
 
 describe('Distribution:', function() {
   it('should be able to execute functionality from distribution build', function() {
@@ -12,7 +12,7 @@ describe('Distribution:', function() {
 
 describe('CLI command:', function() {
   it('should be able to run CLI command', function() {
-    exec('./bin/rlp encode "[ 5 ]"', (_error, stdout, _stderr) => {
+    exec('../bin/rlp encode "[ 5 ]"', (_error, stdout, _stderr) => {
       assert.equal(stdout.trim(), 'c105')
     })
   })

--- a/test/official.spec.ts
+++ b/test/official.spec.ts
@@ -16,7 +16,7 @@ describe('offical tests', function() {
       }
 
       const encoded = RLP.encode(incoming)
-      assert.equal(encoded.toString('hex'), officalTests[testName].out.toLowerCase())
+      assert.equal('0x' + encoded.toString('hex'), officalTests[testName].out.toLowerCase())
       done()
     })
   }


### PR DESCRIPTION
Upstream official tests added the `0x` prefix to values. This PR adds a `0x` to computed values when checking against expected values.