### PR TITLE
Change 'array instanceof array' to 'Array.isArray()' 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ethereumjs/config-tslint": "^1.0.0",
     "@types/bn.js": "^4.11.3",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.12.2",    
+    "@types/node": "^10.12.2",
     "coveralls": "^2.11.4",
     "mocha": "4.1.0",
     "nyc": "^13.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { Decoded, Dictionary, Input, List }
  * @returns returns buffer of encoded data
  **/
 export function encode(input: Input): Buffer {
-  if (input instanceof Array) {
+  if (Array.isArray(input)) {
     const output: Buffer[] = []
     for (let i = 0; i < input.length; i++) {
       output.push(encode(input[i]))


### PR DESCRIPTION
Changing this little thing, fixes a bug we had when running RLP with arrays in https://github.com/gnosis/hg-first-decentralized-market.

Specifically in the migrations script `migrations/2_pmSystem_migrations` which doesn't work with the older input instanceof Array, strangely.  