### PR TITLE
Remove Dictionary type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import BN = require('bn.js')
 
-import { Decoded, Dictionary, Input, List } from './types'
+import { Decoded, Input, List } from './types'
 
 // Types exported outside of this package
-export { Decoded, Dictionary, Input, List }
+export { Decoded, Input, List }
 
 /**
  * RLP Encoding based on: https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-RLP

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,10 @@
 import BN = require('bn.js')
 
-export type Input = Buffer | string | number | Uint8Array | BN | Dictionary | List | null
+export type Input = Buffer | string | number | Uint8Array | BN | List | null
 
 // Use interface extension instead of type alias to
 // make circular declaration possible.
 export interface List extends Array<Input> {}
-
-export interface Dictionary {
-  [x: string]: Input
-}
 
 export interface Decoded {
   data: Buffer | Buffer[]


### PR DESCRIPTION
This PR just removes the unused `Dictionary` type.

As I said in #62, if an actual `Dictionary` is given to `encode()` it throws. This change only makes that case fail at compile-time.