### PR TITLE
Move BN.js from deps to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "url": "https://github.com/ethereumjs/rlp/issues"
   },
   "dependencies": {
-    "safe-buffer": "^5.1.1",
-    "bn.js": "^4.11.1"
+    "safe-buffer": "^5.1.1"
   },
   "devDependencies": {
     "@ethereumjs/config-nyc": "^1.0.0",
@@ -62,6 +61,7 @@
     "@types/bn.js": "^4.11.3",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.2",
+    "bn.js": "^4.11.8",
     "coveralls": "^2.11.4",
     "husky": "^2.1.0",
     "mocha": "4.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import BN = require('bn.js')
-
 import { Decoded, Input, List } from './types'
 
 // Types exported outside of this package
@@ -244,12 +243,23 @@ function toBuffer(v: Input): Buffer {
       return Buffer.from([])
     } else if (v instanceof Uint8Array) {
       return Buffer.from(v as any)
-    } else if (BN.isBN(v)) {
+    } else if (isBN(v)) {
       // converts a BN to a Buffer
-      return Buffer.from(v.toArray())
+      return v.toArrayLike(Buffer)
     } else {
       throw new Error('invalid type')
     }
   }
   return v
+}
+
+/** Check if value is a BN instance */
+function isBN(value: any): value is BN {
+  if (typeof value.constructor.isBN !== 'function') {
+    return false
+  } else if (typeof value.toArrayLike !== 'function') {
+    return false
+  } else {
+    return true
+  }
 }


### PR DESCRIPTION
I've used feature detection instead of BN's method invocation to decide if there is a BN instance. This feature detection relies on two methods `isBN` and `toArrayLike` of BN's interface. It allows to remove BN from the list of dependencies (anyway rlp could receive any of the BN version here, according to BN's `isBN` method [implementation](https://github.com/indutny/bn.js/blob/master/lib/bn.js#L57)) to devDependencies and avoid double conversion BN to Array and Array to Buffer.