### PR TITLE
Use NestedBufferArray for decode's return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import BN = require('bn.js')
 
-import { Decoded, Input, List } from './types'
+import { Decoded, Input, List, NestedBufferArray } from './types'
 
 // Types exported outside of this package
-export { Decoded, Input, List }
+export { Decoded, Input, List, NestedBufferArray }
 
 /**
  * RLP Encoding based on: https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-RLP
@@ -54,13 +54,9 @@ function encodeLength(len: number, offset: number): Buffer {
 /**
  * RLP Decoding based on: {@link https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-RLP|RLP}
  * @param input - will be converted to buffer
- * @param stream - Is the input a stream (false by default)
  * @returns - returns decode Array of Buffers containg the original message
  **/
-export function decode(input: Buffer, stream?: boolean): Buffer
-export function decode(input: Buffer[], stream?: boolean): Buffer[]
-export function decode(input: Input, stream?: boolean): Buffer[] | Buffer | Decoded
-export function decode(input: Input, stream: boolean = false): Buffer[] | Buffer | Decoded {
+export function decode(input: Buffer): Buffer | NestedBufferArray {
   if (!input || (<any>input).length === 0) {
     return Buffer.from([])
   }
@@ -68,14 +64,27 @@ export function decode(input: Input, stream: boolean = false): Buffer[] | Buffer
   const inputBuffer = toBuffer(input)
   const decoded = _decode(inputBuffer)
 
-  if (stream) {
-    return decoded
-  }
   if (decoded.remainder.length !== 0) {
     throw new Error('invalid remainder')
   }
 
   return decoded.data
+}
+
+/**
+ * Streaming version of RLP decoding.
+ * @param input - will be converted to buffer
+ * @returns - returns `Decoded` object which has decoded data, and remainder
+ **/
+export function decodeStreaming(input: Buffer): Decoded {
+  if (!input || (<any>input).length === 0) {
+    return { data: Buffer.from([]), remainder: Buffer.alloc(0) }
+  }
+
+  const inputBuffer = toBuffer(input)
+  const decoded = _decode(inputBuffer)
+
+  return decoded
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export type Input = Buffer | string | number | bigint | Uint8Array | BN | List |
 export interface List extends Array<Input> {}
 
 export interface Decoded {
-  data: Buffer | Buffer[]
+  data: Buffer | NestedBufferArray
   remainder: Buffer
 }
+
+export interface NestedBufferArray extends Array<Buffer | NestedBufferArray> {}

--- a/test/dataTypes.spec.ts
+++ b/test/dataTypes.spec.ts
@@ -206,8 +206,12 @@ describe('strings over 55 bytes long', function () {
 
   it('should decode (using decodeStreaming)', function () {
     const decoded = RLP.decodeStreaming(encoded)
-    assert.equal(decoded.data.toString(), testString)
+    assert.strictEqual(decoded.data.toString(), testString)
     assert.ok(decoded.remainder.equals(Buffer.alloc(0)))
+  })
+  it('shoudl return empty array (with decodeStreaming)', function () {
+    const decoded = RLP.decodeStreaming(Buffer.from([]))
+    assert.ok(decoded.data.length === 0)
   })
 })
 

--- a/test/dataTypes.spec.ts
+++ b/test/dataTypes.spec.ts
@@ -415,8 +415,8 @@ describe('recursive typings', function () {
   it('should not throw compilation error', function () {
     type IsType<T, U> = Exclude<T, U> extends never
       ? Exclude<U, T> extends never
-      ? true
-      : false
+        ? true
+        : false
       : false
     const assertType = <T, U>(isTrue: IsType<T, U>) => {
       return isTrue

--- a/test/dataTypes.spec.ts
+++ b/test/dataTypes.spec.ts
@@ -315,7 +315,7 @@ describe('zero values', function () {
 
   it('decode a zero (using decodeStreaming)', function () {
     const decode = RLP.decodeStreaming(Buffer.from([0]))
-    assert.deepEqual(decode, { data: Buffer.from([0]), remainder: Buffer.alloc(0) })
+    assert.deepStrictEqual(decode, { data: Buffer.from([0]), remainder: Buffer.alloc(0) })
   })
 })
 
@@ -407,7 +407,7 @@ describe('hex prefix', function () {
   it('should have the same value', function () {
     const a = RLP.encode('0x88f')
     const b = RLP.encode('88f')
-    assert.notEqual(a.toString('hex'), b.toString('hex'))
+    assert.notStrictEqual(a.toString('hex'), b.toString('hex'))
   })
 })
 

--- a/test/dataTypes.spec.ts
+++ b/test/dataTypes.spec.ts
@@ -181,6 +181,12 @@ describe('strings over 55 bytes long', function() {
     const decoded = RLP.decode(encoded)
     assert.equal(decoded.toString(), testString)
   })
+
+  it('should decode (using decodeStreaming)', function() {
+    const decoded = RLP.decodeStreaming(encoded)
+    assert.equal(decoded.data.toString(), testString)
+    assert.ok(decoded.remainder.equals(Buffer.alloc(0)))
+  })
 })
 
 describe('list over 55 bytes long', function() {
@@ -283,6 +289,11 @@ describe('zero values', function() {
   it('decode a zero', function() {
     const decode = RLP.decode(Buffer.from([0]))
     assert.deepEqual(decode, Buffer.from([0]))
+  })
+
+  it('decode a zero (using decodeStreaming)', function() {
+    const decode = RLP.decodeStreaming(Buffer.from([0]))
+    assert.deepEqual(decode, { data: Buffer.from([0]), remainder: Buffer.alloc(0) })
   })
 })
 

--- a/test/dataTypes.spec.ts
+++ b/test/dataTypes.spec.ts
@@ -77,11 +77,23 @@ describe('RLP encoding (list):', function() {
     assert.equal(encodedArrayOfStrings[1], 131)
     assert.equal(encodedArrayOfStrings[11], 97)
     assert.equal(encodedArrayOfStrings[12], 116)
+    assert.equal(RLP.getLength(encodedArrayOfStrings), 13)
   })
 
-  // it('length of list >55 should return 0xf7+len(len(data)) plus len(data) plus data', function () {
-  //   // need a test case here!
-  // })
+  it('length of list >55 should return 0xf7+len(len(data)) plus len(data) plus data', function() {
+    // prettier-ignore
+    const testString = ['This', 'function', 'takes', 'in', 'a', 'data', 'convert', 'it', 'to', 'buffer', 'if', 'not', 'and', 'a', 'length', 'for', 'recursion', 'a1', 'a2', 'a3', 'ia4', 'a5', 'a6', 'a7', 'a8', 'ba9']
+    const encoded = RLP.encode(testString)
+    assert.equal(114, encoded.length)
+    assert.equal(encoded[0], 248)
+    assert.equal(encoded[1], 112)
+    assert.equal(encoded[2], 132)
+    assert.equal(encoded[3], 84)
+    assert.equal(encoded[11], 99)
+    assert.equal(encoded[12], 116)
+    assert.equal(encoded[13], 105)
+    assert.equal(RLP.getLength(encoded), 114)
+  })
 })
 
 describe('RLP encoding (BigInt):', function() {


### PR DESCRIPTION
This PR is a breaking change. It changes the signature of `decode` to (see #78 for discussion):

```typescript
export function decode(input: Buffer): Buffer | NestedBufferArray {
```

It moves the streaming version to a new method `decodeStreaming`:

```typescript
export function decodeStreaming(input: Buffer): Decoded {
```

I personally have a hard time figuring out the use-case for `decodeStreaming`?

I think generally working with this `decode` API is hard and given the nature of RLP, we can modify the API to accept some type hints from the user and improve decoding experience. Other RLP libraries have various approaches for this.

- pyrlp uses type hints called sedes which are passed to `decode` function (see [tutorial](https://pyrlp.readthedocs.io/en/latest/tutorial.html#sedes-objects))
- the rust rlp impl keeps the serialized buffer in a struct and offers an [API](https://docs.rs/rlp/0.4.0/rlp/struct.Rlp.html) for getting different parts. E.g. you'd construct an `Rlp` object, and then call `rlp.val_at(1)` to get buffer at index 1, and `rlp.list_at(2)` to get list at index 2

What do others think? @holgerd77 @alcuadrado 