### PR TITLE
Add bigint support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ function stripHexPrefix(str: string): string {
 }
 
 /** Transform an integer into its hexadecimal value */
-function intToHex(integer: number): string {
+function intToHex(integer: number | bigint): string {
   if (integer < 0) {
     throw new Error('Invalid integer as argument, must be unsigned!')
   }
@@ -220,7 +220,7 @@ function padToEven(a: string): string {
 }
 
 /** Transform an integer into a Buffer */
-function intToBuffer(integer: number): Buffer {
+function intToBuffer(integer: number | bigint): Buffer {
   const hex = intToHex(integer)
   return Buffer.from(hex, 'hex')
 }
@@ -234,7 +234,7 @@ function toBuffer(v: Input): Buffer {
       } else {
         return Buffer.from(v)
       }
-    } else if (typeof v === 'number') {
+    } else if (typeof v === 'number' || typeof v === 'bigint') {
       if (!v) {
         return Buffer.from([])
       } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import BN = require('bn.js')
 
-export type Input = Buffer | string | number | Uint8Array | BN | List | null
+export type Input = Buffer | string | number | bigint | Uint8Array | BN | List | null
 
 // Use interface extension instead of type alias to
 // make circular declaration possible.

--- a/test/dataTypes.spec.ts
+++ b/test/dataTypes.spec.ts
@@ -61,6 +61,13 @@ describe('RLP encoding (list):', function() {
   // })
 })
 
+describe('RLP encoding (BigInt):', function() {
+  it('should encode a BigInt value', function() {
+    const encodedBN = RLP.encode(BigInt(3))
+    assert.equal(encodedBN[0], 3)
+  })
+})
+
 describe('RLP encoding (BN):', function() {
   it('should encode a BN value', function() {
     const encodedBN = RLP.encode(new BN(3))

--- a/test/dataTypes.spec.ts
+++ b/test/dataTypes.spec.ts
@@ -1,3 +1,4 @@
+import { version } from 'process'
 import * as assert from 'assert'
 import * as RLP from '../src'
 const BN = require('bn.js')
@@ -62,6 +63,13 @@ describe('RLP encoding (list):', function() {
 })
 
 describe('RLP encoding (BigInt):', function() {
+  before(function() {
+    const nodeVersionNumber = Number(version.match(/^v([0-9]+)/)![1])
+    if (nodeVersionNumber < 10) {
+      // tslint:disable-next-line no-invalid-this
+      this.skip()
+    }
+  })
   it('should encode a BigInt value', function() {
     const encodedBN = RLP.encode(BigInt(3))
     assert.equal(encodedBN[0], 3)


### PR DESCRIPTION
The logic for `number` encoding works fine for `bigint`s.
- Add `bigint` to `Input` type
- Add `typeof` check to allow `bigint` encoding to share `number` encoding code path
- Add simple unit test to verify `bigint` encoding