### PR TITLE
Remove package.json `testling` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,18 +76,5 @@
   },
   "bin": {
     "rlp": "./bin/rlp"
-  },
-  "testling": {
-    "files": "test/*.js",
-    "harness": "mocha-bdd",
-    "browsers": [
-      "chrome/22..latest",
-      "firefox/16..latest",
-      "safari/latest",
-      "opera/11.0..latest",
-      "iphone/6",
-      "ipad/6",
-      "android-browser/latest"
-    ]
   }
 }


### PR DESCRIPTION
This is a small cleanup PR that removes the `testling` property in `package.json` since in #87 we moved to a karma test runner for browser testing.