### PR TITLE
Update `actions/checkout` to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       
       - run: npm install
       - run: npm run test
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: 12.x
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       
       - run: npm install
       - run: npm run coverage


### PR DESCRIPTION
This PR solves the following issue in gh actions when uploading coverage to coveralls:

```
[error] "2020-07-10T20:06:25.737Z"  'error from getOptions'
##[error]Error: Command failed: git cat-file -p 3ebc75f2f9e2e2368d93fd9c4d671536713be8de
fatal: Not a valid object name 3ebc75f2f9e2e2368d93fd9c4d671536713be8de
```

See [here](https://github.com/coverallsapp/github-action/issues/55) for more details.