### PR TITLE
Improve cli interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ assert.deepEqual(nestedList, decoded)
 
 ## CLI
 
-`rlp decode <hex string>`  
-`rlp encode <json String>`
+`rlp encode <json string>`
+`rlp decode <hex string>`
+
+Examples:
+
+- `rlp encode 5` => `0x05`
+- `rlp encode '[5]'` => `0xc105`
+- `rlp encode '["cat", "dog"]'` => `0xc88363617483646f67`
+- `rlp decode 0xc88363617483646f67` => `["cat","dog"]`
 
 ## TESTS
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ assert.deepEqual(nestedList, decoded)
 
 ## CLI
 
-`rlp encode <json string>`
-`rlp decode <hex string>`
+`rlp encode <JSON string>`
+`rlp decode <0x-prefixed hex string>`
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ assert.deepEqual(nestedList, decoded)
 `rlp encode <json string>`
 `rlp decode <hex string>`
 
-Examples:
+### Examples
 
-- `rlp encode 5` => `0x05`
+- `rlp encode '5'` => `0x05`
 - `rlp encode '[5]'` => `0xc105`
 - `rlp encode '["cat", "dog"]'` => `0xc88363617483646f67`
 - `rlp decode 0xc88363617483646f67` => `["cat","dog"]`

--- a/bin/rlp
+++ b/bin/rlp
@@ -42,7 +42,7 @@ if (method === 'encode') {
  */
 function baToJSON(ba) {
   if (Buffer.isBuffer(ba)) {
-    return ba.toString()
+    return ba.toString('hex')
   } else if (ba instanceof Array) {
     const arr = []
     for (let i = 0; i < ba.length; i++) {

--- a/bin/rlp
+++ b/bin/rlp
@@ -2,34 +2,44 @@
 
 const rlp = require('../dist/index.js')
 const method = process.argv[2]
-const raw = process.argv[3]
+const strInput = process.argv[3]
+
+if (typeof strInput !== 'string') {
+  return console.error(`Expected JSON string input, received type: ${typeof strInput}`)
+}
 
 if (method === 'encode') {
   // Parse JSON
   let json
   try {
-    json = JSON.parse(raw)
-  } catch (e) {
-    return console.error('Error: Could not parse json')
+    json = JSON.parse(strInput)
+  } catch (error) {
+    return console.error(`Error could not parse JSON: ${JSON.stringify(error)}`)
   }
+
+  // Encode RLP
   try {
     const encoded = rlp.encode(json)
     console.log('0x' + encoded.toString('hex'))
   } catch (e) {
-    console.error('Error encoding: ' + e)
+    console.error(`Error encoding RLP: ${JSON.stringify(error)}`)
   }
 } else if (method === 'decode') {
+  // Decode
   try {
-    const decoded = rlp.decode(raw)
+    const decoded = rlp.decode(strInput)
     const json = JSON.stringify(baToJSON(decoded))
     console.log(json)
-  } catch (e) {
-    console.error('Error decoding: ' + e)
+  } catch (error) {
+    console.error(`Error decoding RLP: ${JSON.stringify(error)}`)
   }
 } else {
   console.error('Unsupported method')
 }
 
+/**
+ * Buffer or Buffer Array to JSON
+ */
 function baToJSON(ba) {
   if (Buffer.isBuffer(ba)) {
     return ba.toString()

--- a/bin/rlp
+++ b/bin/rlp
@@ -1,35 +1,43 @@
 #!/usr/bin/env node
 
 const rlp = require('../dist/index.js')
-const command = process.argv[2]
-var raw = process.argv[3]
+const method = process.argv[2]
+const raw = process.argv[3]
 
-if (command === 'encode') {
+if (method === 'encode') {
+  // Parse JSON
+  let json
   try {
-    const json = JSON.parse(raw)
-    console.log(rlp.encode(json).toString('hex'))
+    json = JSON.parse(raw)
   } catch (e) {
-    console.log('invalid json')
+    return console.error('Error: Could not parse json')
+  }
+  try {
+    const encoded = rlp.encode(json)
+    console.log('0x' + encoded.toString('hex'))
+  } catch (e) {
+    console.error('Error encoding: ' + e)
+  }
+} else if (method === 'decode') {
+  try {
+    const decoded = rlp.decode(raw)
+    const json = JSON.stringify(baToJSON(decoded))
+    console.log(json)
+  } catch (e) {
+    console.error('Error decoding: ' + e)
   }
 } else {
-  if (!raw) {
-    raw = command
-  }
-  try {
-    console.log(baToJSON(rlp.decode(raw)))
-  } catch (e) {
-    console.log('invalid RLP' + e)
-  }
+  console.error('Unsupported method')
 }
 
-function baToJSON (ba) {
+function baToJSON(ba) {
   if (Buffer.isBuffer(ba)) {
-    return ba.toString('hex')
+    return ba.toString()
   } else if (ba instanceof Array) {
-    var array = []
-    for (var i = 0; i < ba.length; i++) {
-      array.push(baToJSON(ba[i]))
+    const arr = []
+    for (let i = 0; i < ba.length; i++) {
+      arr.push(baToJSON(ba[i]))
     }
-    return array
+    return arr
   }
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
 import { exec } from 'child_process'
+import { promisify } from 'util'
 import * as RLP from '../dist'
 import * as vm from 'vm'
 
@@ -11,11 +12,33 @@ describe('Distribution:', function() {
   })
 })
 
+const execAsync = promisify(exec)
+
 describe('CLI command:', function() {
-  it('should be able to run CLI command', function() {
-    exec('./bin/rlp encode "[ 5 ]"', (_error, stdout, _stderr) => {
-      assert.equal(stdout.trim(), 'c105')
-    })
+  it('should be able to run CLI command', async function() {
+    const result = await execAsync('./bin/rlp encode "[ 5 ]"')
+    const resultFormatted = result.stdout.trim()
+    assert.equal(resultFormatted, '0xc105')
+  })
+
+  const officalTests = require('./fixture/rlptest.json').tests
+  it('should return valid values for official tests', async function() {
+    // tslint:disable-next-line
+    this.timeout(10000)
+
+    for (const testName in officalTests) {
+      const { in: incoming, out } = officalTests[testName]
+
+      // skip if testing a big number
+      if (incoming[0] === '#') {
+        continue
+      }
+
+      const json = JSON.stringify(incoming)
+      const encodeResult = await execAsync(`./bin/rlp encode '${json}'`)
+      const encodeResultTrimmed = encodeResult.stdout.trim()
+      assert.equal(encodeResultTrimmed, out.toLowerCase(), `should pass encoding ${testName}`)
+    }
   })
 })
 


### PR DESCRIPTION
This PR:

* Updates `rlp encode` to return result with `0x` prefix
  * e.g. `rlp encode '["cat", "dog"]'` => `0xc88363617483646f67`
* Decodes buffers to plain strings (instead of hex strings), and `JSON.stringify`s the output so the result can be used easily again in `rlp encode`.
  * before: `rlp decode 0xc88363617483646f67` => `[ '636174', '646f67' ]`
  * now: => `["cat","dog"]` 
* Adds better error handling on wrong usage of the cli
* Adds tests with `rlptests.json` to ensure cli `encode` returns expected output.
* Adds examples to readme

Closes #94