### PR TITLE
Fix missing sources in package distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**",
-    "bin/**"
+    "bin/**",
+    "src/**"
   ],
   "scripts": {
     "build": "tsc -p ./tsconfig.prod.json",


### PR DESCRIPTION
Source map refers to missing source file: '../src/index.ts', what makes source maps useless and lead to errors:

```text
Could not load source file "../src/index.ts" in source map of "node_modules/rlp/dist/index.js"
```

Currently there are `/bin` and `/dist` folders [bundled](https://unpkg.com/browse/rlp@2.2.6/). I assume there should be sources too. So I've added `/src` dir to package distribution.

