### PR TITLE
Use BN type instead of value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import BN = require('bn.js')
 
-export type Input = Buffer | string | number | bigint | Uint8Array | BN | List | null
+export type Input = Buffer | string | number | bigint | Uint8Array | typeof BN | List | null
 
 // Use interface extension instead of type alias to
 // make circular declaration possible.


### PR DESCRIPTION
At the moment, this module fails to import in Deno because of a type error:

```
error: TS2749 [ERROR]: 'BN' refers to a value, but is being used as a type here. Did you mean 'typeof BN'?
export declare type Input = Buffer | string | number | bigint | Uint8Array | BN | List | null;
```

this PR adds a `typeof` keyword, so this works on both Node.js and Deno