### PR TITLE
Avoid creating new array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export function encode(input: Input): Buffer {
  * @param base The base to parse the integer into
  */
 function safeParseInt(v: string, base: number): number {
-  if (v.slice(0, 2) === '00') {
+  if (v[0] === '0' && v[1] === '0') {
     throw new Error('invalid RLP: extra zeros')
   }
 


### PR DESCRIPTION
Tiny performance improvement with checking first two chars with '0' instead of checking new string wiht '00'

According MDN:
_Array.prototype.slice()_
The _slice()_ method returns a shallow copy of a portion of an array **into a new array object** selected from start to end (end not included) where start and end represent the index of items in that array.

Performance tests:
```js
> f_01 = n => {var x=0;while(n--) {var s=String(Math.random()*10); if (s[0] === '0' && s[1] === '0') x++}return x};
[Function: f_01]
> f_slice = n => {var x=0;while(n--) {var s=String(Math.random()*10); if (s.slice(0,2) === '00') x++}return x};
[Function: f_slice]
> n=1e6;console.time(n);f_slice(n);console.timeEnd(n);
1000000: 283.498ms
undefined
> n=1e6;console.time(n);f_01(n);console.timeEnd(n);
1000000: 261.283ms
undefined
> n=1e8;console.time(n);f_slice(n);console.timeEnd(n);
100000000: 25.068s
undefined
> n=1e8;console.time(n);f_01(n);console.timeEnd(n);
100000000: 23.241s
undefined
```