### PR TITLE
Remove getLength method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,36 +92,6 @@ export function decode(input: Input, stream: boolean = false): Buffer[] | Buffer
   return decoded.data
 }
 
-/**
- * Get the length of the RLP input
- * @param input
- * @returns The length of the input or an empty Buffer if no input
- */
-export function getLength(input: Input): Buffer | number {
-  if (!input || (input as any).length === 0) {
-    return Buffer.from([])
-  }
-
-  const inputBuffer = toBuffer(input)
-  const firstByte = inputBuffer[0]
-
-  if (firstByte <= 0x7f) {
-    return inputBuffer.length
-  } else if (firstByte <= 0xb7) {
-    return firstByte - 0x7f
-  } else if (firstByte <= 0xbf) {
-    return firstByte - 0xb6
-  } else if (firstByte <= 0xf7) {
-    // a list between  0-55 bytes long
-    return firstByte - 0xbf
-  } else {
-    // a list  over 55 bytes long
-    const llength = firstByte - 0xf6
-    const length = safeParseInt(safeSlice(inputBuffer, 1, llength).toString('hex'), 16)
-    return llength + length
-  }
-}
-
 /** Decode an input with RLP */
 function _decode(input: Buffer): Decoded {
   let length, llength, data, innerRemainder, d

--- a/test/dataTypes.spec.ts
+++ b/test/dataTypes.spec.ts
@@ -45,13 +45,11 @@ describe('RLP encoding (string):', function () {
   it('should return itself if single byte and less than 0x7f:', function () {
     const encodedSelf = RLP.encode('a')
     assert.strictEqual(encodedSelf.toString(), 'a')
-    assert.strictEqual(RLP.getLength(encodedSelf), 1)
   })
 
   it('length of string 0-55 should return (0x80+len(data)) plus data', function () {
     const encodedDog = RLP.encode('dog')
     assert.strictEqual(4, encodedDog.length)
-    assert.strictEqual(RLP.getLength(encodedDog), 4)
     assert.strictEqual(encodedDog[0], 131)
     assert.strictEqual(encodedDog[1], 100)
     assert.strictEqual(encodedDog[2], 111)
@@ -63,7 +61,6 @@ describe('RLP encoding (string):', function () {
       'zoo255zoo255zzzzzzzzzzzzssssssssssssssssssssssssssssssssssssssssssssss'
     )
     assert.strictEqual(72, encodedLongString.length)
-    assert.strictEqual(RLP.getLength(encodedLongString), 2)
     assert.strictEqual(encodedLongString[0], 184)
     assert.strictEqual(encodedLongString[1], 70)
     assert.strictEqual(encodedLongString[2], 122)
@@ -75,7 +72,6 @@ describe('RLP encoding (string):', function () {
 describe('RLP encoding (list):', function () {
   it('length of list 0-55 should return (0xc0+len(data)) plus data', function () {
     const encodedArrayOfStrings = RLP.encode(['dog', 'god', 'cat'])
-    assert.strictEqual(RLP.getLength(encodedArrayOfStrings), 13)
     assert.strictEqual(13, encodedArrayOfStrings.length)
     assert.strictEqual(encodedArrayOfStrings[0], 204)
     assert.strictEqual(encodedArrayOfStrings[1], 131)
@@ -91,7 +87,6 @@ describe('RLP encoding (list):', function () {
       'zoo255zoo255zzzzzzzzzzzzssssssssssssssssssssssssssssssssssssssssssssss',
     ]
     const encodedArrayOfStrings = RLP.encode(data)
-    assert.strictEqual(RLP.getLength(encodedArrayOfStrings), 86)
     const str = encodedArrayOfStrings.toString()
     for (const innerStr of data) {
       assert.ok(str.includes(innerStr))

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -7,7 +7,6 @@ describe('Distribution:', function () {
   it('should be able to execute functionality from distribution build', function () {
     const encodedSelf = RLP.encode('a')
     assert.strictEqual(encodedSelf.toString(), 'a')
-    assert.strictEqual(RLP.getLength(encodedSelf), 1)
   })
 })
 


### PR DESCRIPTION
This PR removes the `getLength` method for various reasons:

1. The method is not used internally. The method is not used in our monorepo.
2. It is unclear what this method should do. It states that it returns the "length" of the RLP. This makes sense for encoded strings; in that case you can return the string length. But what about lists? Should you return the number of items in the list? Or should you return the sum of the string length of the lists (recursively? also including nested lists?). And what about empty lists? What is the "length" of `[[], [1], [[], 2, 3, [4]]]`?

@wanderer it seems like you introduced this method in [this commit](https://github.com/ethereumjs/rlp/commit/aa44e67b912d4bf9cd0d0f6f0cf792a435ad138e). Do you remember the motivation of creating this method? And what should it do? Thanks :smile: 